### PR TITLE
exclude example in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,8 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext"
-  }
+  },
+  "exclude": [
+    "example"
+  ]
 }


### PR DESCRIPTION
Hi, we are hacking for euvsvirus and want test and use this repo.
When adding this repo as dependency via yarn add https://github.com/fmauquie/react-native-dp3t
also the example folder is build via tsc and throws errors.